### PR TITLE
Align CSS with Tailwind colors

### DIFF
--- a/andagonApp3/Components/Layout/MainLayout.razor.css
+++ b/andagonApp3/Components/Layout/MainLayout.razor.css
@@ -9,12 +9,14 @@ main {
 }
 
 .sidebar {
-    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+    /* Tailwind slate to purple gradient */
+    background-image: linear-gradient(180deg, #1e293b 0%, #581c87 70%);
 }
 
 .top-row {
-    background-color: #f7f7f7;
-    border-bottom: 1px solid #d6d5d5;
+    /* Tailwind gray-100 background and gray-300 border */
+    background-color: #f3f4f6;
+    border-bottom: 1px solid #d1d5db;
     justify-content: flex-end;
     height: 3.5rem;
     display: flex;

--- a/andagonApp3/Components/Layout/NavMenu.razor.css
+++ b/andagonApp3/Components/Layout/NavMenu.razor.css
@@ -17,7 +17,8 @@
 
 .top-row {
     min-height: 3.5rem;
-    background-color: rgba(0,0,0,0.4);
+    /* Tailwind gray-800 at 50% opacity */
+    background-color: rgba(31, 41, 55, 0.5);
 }
 
 .navbar-brand {
@@ -80,7 +81,8 @@
     }
 
     .nav-item ::deep .nav-link {
-        color: #d7d7d7;
+        /* Tailwind gray-300 text */
+        color: #d1d5db;
         background: none;
         border: none;
         border-radius: 4px;
@@ -92,12 +94,14 @@
     }
 
 .nav-item ::deep a.active {
-    background-color: rgba(255,255,255,0.37);
+    /* Tailwind gray-100 background */
+    background-color: rgba(243,244,246,0.4);
     color: white;
 }
 
 .nav-item ::deep .nav-link:hover {
-    background-color: rgba(255,255,255,0.1);
+    /* subtle hover using gray-100 */
+    background-color: rgba(243,244,246,0.1);
     color: white;
 }
 

--- a/andagonApp3/wwwroot/app.css
+++ b/andagonApp3/wwwroot/app.css
@@ -1,19 +1,28 @@
 html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /* Tailwind's default sans serif stack */
+    font-family: ui-sans-serif, system-ui, -apple-system,
+        BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, "Noto Sans",
+        sans-serif, "Apple Color Emoji",
+        "Segoe UI Emoji", "Segoe UI Symbol",
+        "Noto Color Emoji";
 }
 
+/* Links use Tailwind blue-600 */
 a, .btn-link {
-    color: #006bb7;
+    color: #2563eb;
 }
 
 .btn-primary {
     color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
+    /* Tailwind blue-600 background and blue-700 border */
+    background-color: #2563eb;
+    border-color: #1d4ed8;
 }
 
 .btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+  /* Tailwind blue-300 focus ring */
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #93c5fd;
 }
 
 .content {
@@ -25,15 +34,18 @@ h1:focus {
 }
 
 .valid.modified:not([type=checkbox]) {
-    outline: 1px solid #26b050;
+    /* Tailwind green-600 */
+    outline: 1px solid #16a34a;
 }
 
 .invalid {
-    outline: 1px solid #e50000;
+    /* Tailwind red-600 */
+    outline: 1px solid #dc2626;
 }
 
 .validation-message {
-    color: #e50000;
+    /* Tailwind red-600 */
+    color: #dc2626;
 }
 
 .blazor-error-boundary {


### PR DESCRIPTION
## Summary
- switch fonts and colors to match Tailwind defaults
- use Tailwind style gradient for sidebar and neutral colors
- update nav menu hues to match Tailwind palette

## Testing
- `dotnet test` *(fails: `dotnet` not found)*