### PR TITLE
Add basic role support

### DIFF
--- a/andagonApp3/Data/ApplicationRoles.cs
+++ b/andagonApp3/Data/ApplicationRoles.cs
@@ -1,0 +1,10 @@
+namespace andagonApp3.Data
+{
+    public static class ApplicationRoles
+    {
+        public const string User = "User";
+        public const string Administrator = "Administrator";
+        public const string Teamleader = "Teamleader";
+        public const string CEO = "CEO";
+    }
+}

--- a/andagonApp3/Data/ApplicationUser.cs
+++ b/andagonApp3/Data/ApplicationUser.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
 
 namespace andagonApp3.Data
 {
     // Add profile data for application users by adding properties to the ApplicationUser class
     public class ApplicationUser : IdentityUser
     {
+        public List<string> Roles { get; set; } = new();
     }
 
 }


### PR DESCRIPTION
## Summary
- define predefined roles
- add roles property to `ApplicationUser`
- implement role management methods in the Mongo user store

## Testing
- `dotnet build --no-restore` *(fails: command not found)*