### PR TITLE
Add setup script for .NET 9 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# andagonApp3
+# Andagon App 3
+
+This repository contains a .NET 9.0 solution consisting of several projects.
+To build the application inside the Codex environment you will need the .NET SDK.
+
+## Setup
+
+Run the provided `setup.sh` script before executing any tests or builds. The
+script installs the required .NET 9 SDK and its prerequisites.
+
+```bash
+./setup.sh
+```
+
+After running the setup script you can build the solution using:
+
+```bash
+dotnet build andagonApp3.sln
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Install required packages for .NET 9 SDK installation
+apt-get update
+apt-get install -y wget apt-transport-https
+
+# Add Microsoft package signing key and repository for .NET
+wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+apt-get update
+
+# Install .NET SDK 9.0 (preview) for building the project
+apt-get install -y dotnet-sdk-9.0
+
+# Clean up apt caches to reduce image size
+apt-get clean


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing the .NET 9 SDK and dependencies
- expand `README.md` with instructions on running the setup script and building the solution

## Testing
- `bash -n setup.sh`