### PR TITLE
Ensure default 'User' role

### DIFF
--- a/andagonApp3/Components/Account/Pages/ExternalLogin.razor
+++ b/andagonApp3/Components/Account/Pages/ExternalLogin.razor
@@ -142,6 +142,10 @@
 
         await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
         await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+        if (!user.Roles.Contains(ApplicationRoles.User))
+        {
+            user.Roles.Add(ApplicationRoles.User);
+        }
 
         var result = await UserManager.CreateAsync(user);
         if (result.Succeeded)

--- a/andagonApp3/Components/Account/Pages/Login.razor
+++ b/andagonApp3/Components/Account/Pages/Login.razor
@@ -6,6 +6,7 @@
 @using andagonApp3.Data
 
 @inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
 @inject ILogger<Login> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
@@ -93,6 +94,12 @@
         if (result.Succeeded)
         {
             Logger.LogInformation("User logged in.");
+            var user = await UserManager.FindByEmailAsync(Input.Email);
+            if (user is not null && !user.Roles.Contains(ApplicationRoles.User))
+            {
+                user.Roles.Add(ApplicationRoles.User);
+                await UserManager.UpdateAsync(user);
+            }
             RedirectManager.RedirectTo(ReturnUrl);
         }
         else if (result.RequiresTwoFactor)

--- a/andagonApp3/Components/Account/Pages/Register.razor
+++ b/andagonApp3/Components/Account/Pages/Register.razor
@@ -72,6 +72,10 @@
         await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
         var emailStore = GetEmailStore();
         await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+        if (!user.Roles.Contains(ApplicationRoles.User))
+        {
+            user.Roles.Add(ApplicationRoles.User);
+        }
         var result = await UserManager.CreateAsync(user, Input.Password);
 
         if (!result.Succeeded)

--- a/andagonApp3/Data/ApplicationUser.cs
+++ b/andagonApp3/Data/ApplicationUser.cs
@@ -6,7 +6,7 @@ namespace andagonApp3.Data
     // Add profile data for application users by adding properties to the ApplicationUser class
     public class ApplicationUser : IdentityUser
     {
-        public List<string> Roles { get; set; } = new();
+        public List<string> Roles { get; set; } = new() { ApplicationRoles.User };
     }
 
 }


### PR DESCRIPTION
## Summary
- add default `User` role to `ApplicationUser`
- assign role during user registration and external login
- ensure existing users get role when logging in

## Testing
- `./setup.sh` *(fails: Could not connect to proxy)*
- `dotnet build andagonApp3.sln` *(fails: command not found)*