### PR TITLE
Implement role-based claims factory

### DIFF
--- a/andagonApp3/Components/Pages/Auth.razor
+++ b/andagonApp3/Components/Pages/Auth.razor
@@ -2,12 +2,17 @@
 
 @using Microsoft.AspNetCore.Authorization
 
-@attribute [Authorize]
+@attribute [Authorize(Roles = "User")]
 
 <PageTitle>Auth</PageTitle>
 
 <h1>You are authenticated</h1>
 
-<AuthorizeView>
-    Hello @context.User.Identity?.Name!
+<AuthorizeView Roles="User">
+    <Authorized>
+        <p class="text-success">Sie sind angemeldet.</p>
+    </Authorized>
+    <NotAuthorized>
+        <p class="text-danger">Sie sind nicht berechtigt.</p>
+    </NotAuthorized>
 </AuthorizeView>

--- a/andagonApp3/Data/ApplicationUserClaimsPrincipalFactory.cs
+++ b/andagonApp3/Data/ApplicationUserClaimsPrincipalFactory.cs
@@ -1,0 +1,27 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace andagonApp3.Data
+{
+    public class ApplicationUserClaimsPrincipalFactory : UserClaimsPrincipalFactory<ApplicationUser>
+    {
+        public ApplicationUserClaimsPrincipalFactory(
+            UserManager<ApplicationUser> userManager,
+            IOptions<IdentityOptions> optionsAccessor)
+            : base(userManager, optionsAccessor)
+        {
+        }
+
+        protected override async Task<ClaimsIdentity> GenerateClaimsAsync(ApplicationUser user)
+        {
+            var identity = await base.GenerateClaimsAsync(user);
+            foreach (var role in user.Roles)
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Role, role));
+            }
+            return identity;
+        }
+    }
+}

--- a/andagonApp3/Program.cs
+++ b/andagonApp3/Program.cs
@@ -23,6 +23,8 @@ builder.Services.AddAuthentication(options =>
     })
     .AddIdentityCookies();
 
+builder.Services.AddAuthorization();
+
 var mongoSection = builder.Configuration.GetSection("MongoDb");
 builder.Services.AddSingleton(new DBManager(mongoSection["DatabaseName"], mongoSection["ConnectionString"]));
 builder.Services.AddSingleton(new OdooManager.OdooManager());
@@ -31,6 +33,8 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
     .AddUserStore<MongoUserStore>()
     .AddSignInManager()
     .AddDefaultTokenProviders();
+
+builder.Services.AddScoped<IUserClaimsPrincipalFactory<ApplicationUser>, ApplicationUserClaimsPrincipalFactory>();
 
 builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();
 
@@ -48,6 +52,9 @@ app.UseHttpsRedirection();
 
 
 app.UseAntiforgery();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()


### PR DESCRIPTION
## Summary
- implement custom `ApplicationUserClaimsPrincipalFactory` to include user roles in claims
- register the factory in the service configuration
- update sample Auth page to use role-based authorization view

## Testing
- `./setup.sh` *(fails: Could not connect to proxy)*
- `dotnet build andagonApp3.sln` *(fails: unable to load the service index)*