### PR TITLE
Fix remembering login state

### DIFF
--- a/andagonApp3/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/andagonApp3/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -41,11 +41,13 @@ namespace Microsoft.AspNetCore.Routing
             });
 
             accountGroup.MapPost("/Logout", async (
+                HttpContext context,
                 ClaimsPrincipal user,
                 [FromServices] SignInManager<ApplicationUser> signInManager,
                 [FromForm] string returnUrl) =>
             {
                 await signInManager.SignOutAsync();
+                context.Response.Cookies.Delete("AuthSession");
                 return TypedResults.LocalRedirect($"~/{returnUrl}");
             });
 

--- a/andagonApp3/Components/Account/Pages/Login.razor
+++ b/andagonApp3/Components/Account/Pages/Login.razor
@@ -3,6 +3,7 @@
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
+@using System.Security.Claims
 @using andagonApp3.Data
 
 @inject SignInManager<ApplicationUser> SignInManager
@@ -89,22 +90,35 @@
     {
         // This doesn't count login failures towards account lockout
         // To enable password failures to trigger account lockout, set lockoutOnFailure: true
-        var result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
-        if (result.Succeeded)
+        var user = await SignInManager.UserManager.FindByEmailAsync(Input.Email);
+        if (user is not null)
         {
-            Logger.LogInformation("User logged in.");
-            RedirectManager.RedirectTo(ReturnUrl);
-        }
-        else if (result.RequiresTwoFactor)
-        {
-            RedirectManager.RedirectTo(
-                "Account/LoginWith2fa",
-                new() { ["returnUrl"] = ReturnUrl, ["rememberMe"] = Input.RememberMe });
-        }
-        else if (result.IsLockedOut)
-        {
-            Logger.LogWarning("User account locked out.");
-            RedirectManager.RedirectTo("Account/Lockout");
+            var check = await SignInManager.CheckPasswordSignInAsync(user, Input.Password, lockoutOnFailure: false);
+            if (check.Succeeded)
+            {
+                var claims = Input.RememberMe
+                    ? new[] { new Claim("remember_me", "true") }
+                    : Array.Empty<Claim>();
+                await SignInManager.SignInWithClaimsAsync(user, Input.RememberMe, claims);
+                HttpContext.Response.Cookies.Append("AuthSession", "true");
+                Logger.LogInformation("User logged in.");
+                RedirectManager.RedirectTo(ReturnUrl);
+            }
+            else if (check.RequiresTwoFactor)
+            {
+                RedirectManager.RedirectTo(
+                    "Account/LoginWith2fa",
+                    new() { ["returnUrl"] = ReturnUrl, ["rememberMe"] = Input.RememberMe });
+            }
+            else if (check.IsLockedOut)
+            {
+                Logger.LogWarning("User account locked out.");
+                RedirectManager.RedirectTo("Account/Lockout");
+            }
+            else
+            {
+                errorMessage = "Error: Invalid login attempt.";
+            }
         }
         else
         {

--- a/andagonApp3/Program.cs
+++ b/andagonApp3/Program.cs
@@ -3,6 +3,8 @@ using andagonApp3.Components.Account;
 using andagonApp3.Data;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authentication;
+using System.Security.Claims;
 using OdooManager;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -54,6 +56,16 @@ app.UseHttpsRedirection();
 app.UseAntiforgery();
 
 app.UseAuthentication();
+app.Use(async (context, next) =>
+{
+    if (context.User.Identity?.IsAuthenticated == true &&
+        !context.User.HasClaim("remember_me", "true") &&
+        !context.Request.Cookies.ContainsKey("AuthSession"))
+    {
+        await context.SignOutAsync(IdentityConstants.ApplicationScheme);
+    }
+    await next();
+});
 app.UseAuthorization();
 
 app.MapStaticAssets();


### PR DESCRIPTION
## Summary
- ensure non-remembered logins expire when the browser closes
- keep a session cookie to avoid immediate logout
- delete the session cookie on logout

## Testing
- `./setup.sh` *(fails: Could not connect to proxy)*
- `dotnet build andagonApp3.sln` *(fails: command not found)*